### PR TITLE
Support Laravel ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     },
     "require": {
-        "illuminate/validation": "^5.1",
-        "illuminate/contracts": "^5.1"
+        "illuminate/validation": "^5.1 || ^6.0",
+        "illuminate/contracts": "^5.1 || ^6.0"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     },
     "require": {
-        "illuminate/validation": "^5.1 || ^6.0",
-        "illuminate/contracts": "^5.1 || ^6.0"
+        "illuminate/validation": "^5.4 || ^6.0",
+        "illuminate/contracts": "^5.4 || ^6.0"
     },
     "minimum-stability": "dev"
 }

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -154,7 +154,7 @@ abstract class AbstractValidator
      */
     protected function getFailMessage()
     {
-        return $this->application->make('translator')->trans(static::EXCEPTION_KEY);
+        return $this->application->make('translator')->get(static::EXCEPTION_KEY);
     }
 
     public function setScenario($scenario)


### PR DESCRIPTION
To add Laravel 6.0 support to this package, it looks like the only change required is to use the `get()` method of the translation service rather than the `trans()` wrapper, which has been removed in Laravel 6.0.

The method signature for `get()` matches the signature for `trans()` since Laravel 5.4 - before that, it had a different signature. Therefore, I would suggest dropping support for versions prior to 5.4 as part of this PR.

These changes are working in our Laravel 6.0 project, but as this package has no tests it would be sensible to test this PR further with other projects.